### PR TITLE
feat: add environment and refine action schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,34 @@
 # BlueSchema
 
-🚀 **This project is seeking funding!** If you believe in the potential of AI-assisted development and standardized code
-generation, consider supporting BlueSchema. Your contribution will help us create a universal schema that bridges AI and
-software development.
+BlueSchema is a collection of JSON Schemas that describe an application in a structured way so AI tools can easily understand every component. The schemas capture entities, actions, data sources, environment variables, access control, and basic views. Each action includes a `description` that explains what the action does, acting as the prompt for AI-assisted tooling.
 
----
+## Why BlueSchema?
 
-## **Introduction**
+Using a schema-driven approach for code generation offers several advantages over direct AI-based code generation:
+- **Speed** – Generating code from a well-defined schema is significantly faster than relying on an AI to write everything from scratch.
+- **Accuracy** – AI-generated code often varies based on the framework, leading to inconsistencies. A standardized schema ensures precise output.
+- **Cost-Effective** – AI-powered coding requires more processing time and iterations, making it more expensive compared to structured generation.
+- **Robustness** – Code generators built on BlueSchema enforce best practices and consistency across different programming languages and frameworks.
 
-BlueSchema aims to create a **JSON schema** capable of defining the **entire structure of an MVC application** with *
-*advanced detail levels**, including **access control, data validation, and basic view representation**.
+## Schemas
 
-This project is designed to generate **boilerplates ready for development** in **any programming framework**, using code
-generators. More importantly, by establishing a **unified standard**, we enable the creation of **JSON files that
-represent applications via AI**, allowing instant code generation with a single click.
+| Schema | Purpose |
+| --- | --- |
+| `application.json` | Entry point that ties together all components of an app. |
+| `core/entity.json` | Describes entities and their fields. |
+| `core/action.json` | Models an action. The `description` acts as the action's prompt. |
+| `core/parameter.json` | Defines parameters accepted by actions. |
+| `core/dataSource.json` | Lists available data sources. |
+| `core/environment.json` | Specifies required environment variables. |
+| `core/access.json` | Rule describing who can access what. |
+| `core/accessControl.json` | Application-wide roles and permissions. |
+| `core/view.json` | Basic view structure for UI components. |
 
-### **Why BlueSchema?**
+## Proposed Code Generators
 
-Using a **schema-driven approach** for code generation offers several advantages over direct AI-based code generation:  
-✅ **Speed** – Generating code from a well-defined schema is significantly faster than relying on an AI to write
-everything from scratch.  
-✅ **Accuracy** – AI-generated code often varies based on the framework, leading to inconsistencies. A standardized
-schema ensures precise output.  
-✅ **Cost-Effective** – AI-powered coding requires more processing time and iterations, making it more expensive compared
-to structured generation.  
-✅ **Robustness** – Code generators built on BlueSchema enforce best practices and consistency across different
-programming languages and frameworks.
+Below is a list of planned code generators for different programming languages and frameworks. The **Package** column will be updated with repository links as generators are developed.
 
----
-
-## **Schemas**
-
-The following schemas define the core structure of BlueSchema:
-
-| Schema Name               | Description                                                                                                     |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------|
-| **`applicationSchema`**   | Defines the overall structure of an application, including models, controllers, and modules.                    |
-| **`modelSchema`**         | Specifies the structure of data models, including columns, data types, constraints, and relationships.          |
-| **`modelColumnSchema`**   | Defines properties of each column in a model, such as type, constraints (unique, required), and default values. |
-| **`relationSchema`**      | Specifies relationships between models (hasOne, hasMany, belongsTo, manyToMany) along with foreign keys.        |
-| **`controllerSchema`**    | Defines the structure of controllers, including their actions and associated models.                            |
-| **`actionSchema`**        | Specifies each action within a controller, defining logic and associated views.                                 |
-| **`viewSchema`**          | Describes the structure of views, including nested rows and columns with elements such as tables and lists.     |
-| **`viewComponentSchema`** | Defines the basic building blocks of a view, such as headings, paragraphs, tables, and cards.                   |
-| **`viewColumnSchema`**    | Defines columns within views, allowing width adjustments and nested components.                                 |
-| **`moduleSchema`**        | Defines application modules, specifying controllers and dependencies.                                           |
-
----
-
-## **Proposed Code Generators**
-
-Below is a list of **planned** code generators for different programming languages and frameworks. The **Package**
-column will be updated with repository links as generators are developed.
-
-### **PHP**
+### PHP
 
 | Framework   | Package |
 |-------------|---------|
@@ -62,7 +37,7 @@ column will be updated with repository links as generators are developed.
 | CodeIgniter | --      |
 | Yii2        | --      |
 
-### **Python**
+### Python
 
 | Framework | Package |
 |-----------|---------|
@@ -70,7 +45,7 @@ column will be updated with repository links as generators are developed.
 | Flask     | --      |
 | FastAPI   | --      |
 
-### **Node.js**
+### Node.js
 
 | Framework  | Package |
 |------------|---------|
@@ -78,7 +53,7 @@ column will be updated with repository links as generators are developed.
 | NestJS     | --      |
 | Koa        | --      |
 
-### **Java**
+### Java
 
 | Framework   | Package |
 |-------------|---------|
@@ -88,11 +63,9 @@ column will be updated with repository links as generators are developed.
 
 ---
 
-BlueSchema is still under development and **not yet ready for production use**. Stay tuned for updates as we expand
-support for various frameworks and integrate AI-assisted application generation.
+BlueSchema is still under development and not yet ready for production use. Stay tuned for updates as we expand support for various frameworks and integrate AI-assisted application generation.
 
 🤝 **Want to contribute?** Feel free to collaborate, suggest improvements, or support the project!
-
 
 - [best-practices.md](docs/best-practices.md)
 - [faq.md](docs/faq.md)
@@ -100,4 +73,3 @@ support for various frameworks and integrate AI-assisted application generation.
 - [integration-guide.md](docs/integration-guide.md)
 - [roadmap.md](docs/roadmap.md)
 - [schema-definition.md](docs/schema-definition.md)
-

--- a/schemas/application.json
+++ b/schemas/application.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/application.json",
+  "title": "Application",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name", "version", "entities", "actions", "dataSources"],
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string", "minLength": 1 },
+    "version": { "type": "string" },
+    "description": { "type": "string" },
+    "license": { "type": "string" },
+    "entities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "./core/entity.json" },
+      "uniqueItems": true
+    },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "./core/action.json" }
+    },
+    "dataSources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "./core/dataSource.json" },
+      "uniqueItems": true
+    },
+    "environment": {
+      "type": "array",
+      "description": "Environment variables required by the application, such as API keys.",
+      "items": { "$ref": "./core/environment.json" },
+      "uniqueItems": true
+    },
+    "accessControl": { "$ref": "./core/accessControl.json" }
+  }
+}

--- a/schemas/core/access.json
+++ b/schemas/core/access.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Access Rule Schema",
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string",
+      "description": "Role required to execute the action"
+    },
+    "prompt": {
+      "type": "string",
+      "description": "Prompt that must be satisfied"
+    }
+  },
+  "oneOf": [
+    { "required": ["role"] },
+    { "required": ["prompt"] }
+  ],
+  "additionalProperties": false
+}

--- a/schemas/core/accessControl.json
+++ b/schemas/core/accessControl.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Access Control Schema",
+  "type": "object",
+  "properties": {
+    "roles": {
+      "type": "array",
+      "description": "List of application roles",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Role name"
+          },
+          "permissions": {
+            "type": "array",
+            "description": "List of permissions granted to the role",
+            "items": { "type": "string" },
+            "uniqueItems": true
+          }
+        },
+        "required": ["name", "permissions"]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "required": ["roles"]
+}

--- a/schemas/core/action.json
+++ b/schemas/core/action.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Action Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Action name in camelCase format"
+    },
+    "route": {
+      "type": "string",
+      "description": "Optional route or endpoint"
+    },
+    "description": {
+      "type": "string"
+    },
+    "parameters": {
+      "type": "array",
+      "description": "Optional parameters for the action",
+      "items": { "$ref": "./parameter.json" },
+      "uniqueItems": true
+    },
+    "responseFormat": {
+      "type": "string",
+      "description": "Expected response format",
+      "enum": ["json", "xml", "html", "text"]
+    },
+    "access": {
+      "type": "array",
+      "description": "Access requirements for the action",
+      "items": { "$ref": "./access.json" },
+      "uniqueItems": true
+    },
+    "view": {
+      "description": "Optional view definition",
+      "$ref": "./view.json"
+    }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/schemas/core/dataSource.json
+++ b/schemas/core/dataSource.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Data Source Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Data source name"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["database", "api", "queue", "file"],
+      "description": "Type of data source"
+    },
+    "config": {
+      "type": "object",
+      "description": "Connection configuration",
+      "additionalProperties": true
+    }
+  },
+  "required": ["name", "type", "config"]
+}

--- a/schemas/core/environment.json
+++ b/schemas/core/environment.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Environment Variable",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the environment variable"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of the variable's purpose"
+    },
+    "required": {
+      "type": "boolean",
+      "description": "Indicates whether the variable is required",
+      "default": true
+    },
+    "default": {
+      "type": "string",
+      "description": "Default value if not provided"
+    }
+  },
+  "required": ["name"]
+}
+

--- a/schemas/core/parameter.json
+++ b/schemas/core/parameter.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameter Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Parameter name"
+    },
+    "in": {
+      "type": "string",
+      "enum": ["query", "path", "header", "cookie"],
+      "description": "Location of the parameter"
+    },
+    "description": {
+      "type": "string"
+    },
+    "required": {
+      "type": "boolean",
+      "description": "Indicates if the parameter is required",
+      "default": false
+    },
+    "schema": {
+      "type": "object",
+      "description": "JSON Schema describing the parameter value"
+    }
+  },
+  "required": ["name", "in"],
+  "additionalProperties": false
+}

--- a/schemas/core/view.json
+++ b/schemas/core/view.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "View Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Identifier for the view"
+    },
+    "type": {
+      "type": "string",
+      "description": "Type of view, such as list, detail, or form"
+    },
+    "components": {
+      "type": "array",
+      "description": "UI components used in the view",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["name", "type"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- drop unused enums from application schema
- add environment variables section and schema
- introduce access control, action, and data source schemas
- refine action schema with route, parameter, responseFormat, access, and view support
- add dedicated schemas for parameters, access rules, and views
- rewrite README to focus on AI tooling and remove funding request

## Testing
- `python -m json.tool schemas/application.json`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49ccfd2448327ad003ff8917f24ed